### PR TITLE
🔒 fix(deps): require chrono >=0.4.20 to close RUSTSEC-2020-0159

### DIFF
--- a/crates/hamoru-cli/Cargo.toml
+++ b/crates/hamoru-cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 hamoru-core = { path = "../hamoru-core" }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.20", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 serde_json = "1"

--- a/crates/hamoru-core/Cargo.toml
+++ b/crates/hamoru-core/Cargo.toml
@@ -10,7 +10,7 @@ test-utils = []
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.20", features = ["serde"] }
 futures = "0.3"
 futures-core = "0.3"
 rand = "0.8"


### PR DESCRIPTION
## Summary
- Tighten chrono version floor from `"0.4"` to `"0.4.20"` in both `hamoru-core` and `hamoru-cli` Cargo.toml
- Mitigates [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159): potential segfault in `localtime_r` on Unix when environment variables are concurrently modified
- **Preventative hardening** — the lockfile already resolves to chrono 0.4.44 (safe), but the previous constraint `"0.4"` allowed versions >=0.4.0 including vulnerable ones
- Actual runtime exposure was minimal: codebase only uses `Utc::now()`, not `Local::now()` (which triggers the vulnerable code path)
- Cargo.lock is unchanged by this PR

## Test plan
- [x] `cargo test --all-targets` — 117 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo deny check advisories` — ok
- [x] Verified Cargo.lock unchanged (resolved chrono 0.4.44 satisfies >=0.4.20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)