### PR TITLE
🔒 fix(deps): require patched minimums for tokio, tracing-subscriber, bytes

### DIFF
--- a/crates/hamoru-cli/Cargo.toml
+++ b/crates/hamoru-cli/Cargo.toml
@@ -10,10 +10,10 @@ chrono = { version = "0.4.20", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1.23.1", features = ["macros", "rt-multi-thread", "fs"] }
 tokio-stream = "0.1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [dev-dependencies]
 hamoru-core = { path = "../hamoru-core", features = ["test-utils"] }

--- a/crates/hamoru-core/Cargo.toml
+++ b/crates/hamoru-core/Cargo.toml
@@ -9,7 +9,7 @@ test-utils = []
 
 [dependencies]
 async-trait = "0.1"
-bytes = "1"
+bytes = "1.11.1"
 chrono = { version = "0.4.20", features = ["serde"] }
 futures = "0.3"
 futures-core = "0.3"
@@ -21,9 +21,9 @@ serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
 tracing = "0.1"
-tokio = { version = "1", features = ["sync", "time", "fs", "rt"] }
+tokio = { version = "1.23.1", features = ["sync", "time", "fs", "rt"] }
 tokio-stream = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "test-util"] }
+tokio = { version = "1.23.1", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "test-util"] }


### PR DESCRIPTION
## Summary

- Raise minimum version floors for three RustSec advisories:
  - **tokio** `"1"` → `"1.23.1"` — closes RUSTSEC-2023-0001 (reject_remote_clients corruption)
  - **tracing-subscriber** `"0.3"` → `"0.3.20"` — closes RUSTSEC-2025-0055 (ANSI escape injection)
  - **bytes** `"1"` → `"1.11.1"` — closes RUSTSEC-2026-0007 (BytesMut::reserve integer overflow)
- `Cargo.lock` already resolves to patched versions; this hardens the floor so future resolutions cannot regress
- Follows the same pattern as the chrono RUSTSEC-2020-0159 fix (commit e6d80ed)

## Test plan

- [x] `cargo test --all-targets` — 117 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `Cargo.lock` unchanged (resolved versions already exceed new floors)
- [ ] `cargo deny check advisories` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)