### PR TITLE
🧹 chore: remove redundant deps.rs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![CI](https://github.com/tyabu12/hamoru/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tyabu12/hamoru/actions/workflows/ci.yml)
 [![Security Audit](https://github.com/tyabu12/hamoru/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/tyabu12/hamoru/actions/workflows/security.yml)
 [![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tyabu12/8c8891a593f77b776e5d672b8dd8ab2c/raw/hamoru-coverage.json)](https://gist.github.com/tyabu12/8c8891a593f77b776e5d672b8dd8ab2c)
-[![dependency status](https://deps.rs/repo/github/tyabu12/hamoru/status.svg)](https://deps.rs/repo/github/tyabu12/hamoru)
 
 **"Terraform for LLMs."**
 


### PR DESCRIPTION
## Summary
- Remove deps.rs dependency status badge from README
- Security Audit badge (`cargo-deny check advisories` in `security.yml`) already covers vulnerability detection
- deps.rs only flagged non-security version staleness as yellow warnings, adding noise

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)