### PR TITLE
📝 docs: revamp README layout and update project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ with policy-based model selection and cost impact prediction.
 > **This project is under active development and is not production-ready.**
 > Use at your own risk. APIs and configuration formats may change without notice.
 
-## Key Differentiators
-
-1. **Declarative Agent Collaboration** — Define LLM collaboration patterns (Generator/Evaluator, Pipeline, Debate) in YAML
-2. **Policy as Code** — Intent-based model selection: `tags: [review] → quality-first policy → Opus auto-selected`
-3. **Cost Impact Prediction** — `hamoru plan` simulates cost changes before applying policy updates
-
 ## Current Phase
 
 **Phase 4a: Orchestration Engine — Sequential**
 
 See [design-plan.md](docs/design-plan.md) for the full roadmap.
+
+## Key Differentiators
+
+1. **Declarative Agent Collaboration** — Define LLM collaboration patterns (Generator/Evaluator, Pipeline, Debate) in YAML
+2. **Policy as Code** — Intent-based model selection: `tags: [review] → quality-first policy → Opus auto-selected`
+3. **Cost Impact Prediction** — `hamoru plan` simulates cost changes before applying policy updates
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Move status notice above Architecture (no heading) for better visibility
- Move Current Phase section before Architecture
- Replace simple layer list with full ASCII architecture diagram from design-plan.md
- Update Project Structure to reflect actual crate layout (provider, telemetry, policy, orchestrator, etc.)

## Test plan
- [x] Verify rendered README on GitHub looks correct
- [x] Check ASCII diagram alignment renders properly in code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)