### PR TITLE
🐛 fix: quote argument-hint to prevent YAML comment truncation

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,7 +1,7 @@
 ---
 description: Orchestrate feature implementation from plan to PR — worktree isolation, TDD, review, and PR creation.
 allowed-tools: Read, Grep, Glob, Bash, Agent, Write, Edit, EnterWorktree, ExitWorktree
-argument-hint: <task-description | #issue-number | phase N>
+argument-hint: "[description | issue-number | phase N]"
 ---
 
 # /implement


### PR DESCRIPTION
## Summary
- The `#` in `/implement`'s `argument-hint` was parsed as a YAML comment, truncating the displayed hint
- Switched to `[bracket]` notation (matching Claude Code's official docs convention) and quoted the value

## Test plan
- [x] Verify `/implement` autocomplete shows the full hint `[description | issue-number | phase N]`
- [x] Verify `/implement #42` still triggers issue-based flow (Step 0 detection unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)