### PR TITLE
🧹 docs: tidy up loose ends from ADR-007 review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,9 @@ Prefix the subject line with a single emoji that captures the spirit of the chan
 | 005 | Policy Engine Design — sync trait, quality tier heuristic, scoring algorithm | design-plan.md Phase 3 |
 | 006 | Orchestration Engine Design — module structure, condition evaluation, warn-not-error | design-plan.md Phase 4a |
 | 007 | Agent Framework Integration Design — content block types, tool_call buffering, SSE progress | Cross-cutting (Phase 5 + type design) |
+| 008 | API Server Crate Placement — axum in hamoru-cli vs dedicated crate | design-plan.md Phase 5 |
 
-Next available number: **008**. Increment sequentially from here.
+Next available number: **009**. Increment sequentially from here.
 
 ## Agent Configuration
 

--- a/docs/decisions/004-telemetry-sqlite-migration.md
+++ b/docs/decisions/004-telemetry-sqlite-migration.md
@@ -1,4 +1,4 @@
-# ADR 004: Telemetry SQLite Migration
+# ADR-004: Telemetry SQLite Migration
 
 ## Status
 

--- a/docs/decisions/007-agent-framework-integration-design.md
+++ b/docs/decisions/007-agent-framework-integration-design.md
@@ -195,7 +195,8 @@ L0+L1 covers the three highest-urgency needs. U4 (step output debugging) is avai
 
 ## Deferred to Future Phases
 
-- **axum crate placement** (Phase 5 start): Whether the HTTP server lives in hamoru-cli, a dedicated `hamoru-server` crate, or elsewhere. Requires a separate ADR per CLAUDE.md.
+- **axum crate placement** (Phase 5 start, ADR-008): Whether the HTTP server lives in hamoru-cli, a dedicated `hamoru-server` crate, or elsewhere. Requires a separate ADR per CLAUDE.md.
+- **ChatResponse content block migration** (Phase 6 reassessment): ChatResponse currently retains flat `content: String` + `tool_calls` fields (see "ChatResponse is NOT changed" above). When Phase 6 introduces thinking blocks, citations, or interleaved text+tool content, ChatResponse may need to evolve to `content: Vec<ContentPart>` or a similar structure. Reassess during Phase 6 trait redesign; if changed, record rationale in a new ADR explaining the departure from this decision.
 - **L2: Step output in extension field** (post-Phase 5): Adds `"step_output"` to L1 events. Opt-in via request header. Requires Hard Rule 8 security review.
 - **L3: Typed SSE events** (post-v1.0): Full semantic event types (`event: hamoru.step.start`). Opt-in mode for hamoru-native UIs/dashboards. Design informed by OpenAI Responses API event types and Anthropic content block lifecycle events. L1 remains the default.
 - **Incremental tool_call streaming** (if demand validated): Upgrade `ChatChunk.tool_calls` from `Option<Vec<ToolCall>>` to `Option<Vec<ToolCallChunk>>` for human-facing UI use cases.

--- a/docs/design-plan.md
+++ b/docs/design-plan.md
@@ -1360,6 +1360,8 @@ response = client.chat.completions.create(
 # → All results returned in OpenAI format
 ```
 
+**Testing note**: The OpenAI-compatible provider is planned post-v1.0, but Phase 5 tool_calls passthrough validation requires end-to-end testing of the OpenAI wire format round-trip (OpenAI format → internal ContentPart → provider format → internal ContentPart → OpenAI format). Consider prioritizing a minimal OpenAI-compat provider adapter (or mock) in Phase 5 to validate the "near-passthrough" path where the wire format and provider format are both OpenAI. Without this, edge cases in the translation layer may go undetected until post-v1.0.
+
 **Learning points**: Understanding OpenAI API spec (including tool_calls wire format), SSE implementation with axum, API gateway design, tool_call buffering strategy, content block translation between provider formats and wire formats.
 
 ### Phase 6: Agent Collaboration Engine (Layer 5 — Core Differentiator)


### PR DESCRIPTION
## Summary

- Fix ADR-004 title typo: `ADR 004` → `ADR-004` (hyphen consistency with all other ADRs)
- Reserve ADR-008 in CLAUDE.md for axum crate placement decision at Phase 5 start
- Add ChatResponse future pressure note to ADR-007 deferred items — reassess if Phase 6 thinking/citations require content blocks
- Add Phase 5 testing note in design-plan.md — OpenAI-compat provider (or mock) needed for E2E tool_calls round-trip validation

## Test plan

- [x] Documentation-only changes — no code modifications
- [x] `cargo test` passes (263 tests, unchanged)
- [x] Annotation content reviewed by subagent for accuracy, tone, and cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)