### PR TITLE
📛 feat: rename CLI binary from hamoru-cli to hamoru

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
           exit ${SMOKE_EXIT:-0}
         env:
-          HAMORU_BIN: target/debug/hamoru-cli
+          HAMORU_BIN: target/debug/hamoru
 
   ollama-smoke:
     name: Ollama Smoke Test
@@ -127,7 +127,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
-        run: cargo build --bin hamoru-cli
+        run: cargo build --bin hamoru
 
       # Version-pinned + install script integrity check.
       # The install script downloads ~1.7 GB (includes GPU libs we don't need,
@@ -184,7 +184,7 @@ jobs:
         run: |
           bash scripts/smoke-test.sh --verbose 2>&1 | tee /tmp/ollama-smoke.log
         env:
-          HAMORU_BIN: target/debug/hamoru-cli
+          HAMORU_BIN: target/debug/hamoru
 
       # Separate step ensures outputs are captured even when smoke test fails.
       # Uses steps.smoke.outcome (not .result) to see the real exit status
@@ -262,14 +262,14 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
-        run: cargo build --bin hamoru-cli
+        run: cargo build --bin hamoru
 
       # SECURITY: Secret is injected via env: directive (not shell expansion).
       # The env_name/secret_name values come from the hardcoded matrix above.
       - name: Smoke test (cloud - ${{ matrix.provider }})
         id: smoke
         env:
-          HAMORU_BIN: target/debug/hamoru-cli
+          HAMORU_BIN: target/debug/hamoru
           ${{ matrix.env_name }}: ${{ secrets[matrix.secret_name] }}
         run: |
           bash scripts/smoke-test.sh --verbose 2>&1 | tee /tmp/cloud-smoke.log

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ See [design-plan.md](docs/design-plan.md) for the full roadmap.
 
 ```bash
 cargo build
-cargo run -p hamoru-cli -- init
+cargo run --bin hamoru -- init
 ```
 
 ### 🏠 Option A: Local LLM (no API key required)
@@ -106,8 +106,8 @@ providers:
 
 ```bash
 ollama pull llama3.2
-cargo run -p hamoru-cli -- providers test
-cargo run -p hamoru-cli -- run -m local:llama3.2 "Hello, world!"
+cargo run --bin hamoru -- providers test
+cargo run --bin hamoru -- run -m local:llama3.2 "Hello, world!"
 ```
 
 ### ☁️ Option B: Cloud LLM (API key required)
@@ -123,21 +123,21 @@ echo  # newline after silent input
 > **Security note:** Avoid typing API keys directly in commands (e.g., `export KEY=sk-ant-...`) — they may be saved in your shell history file. Use `read -rs` as shown above, or load from a secrets manager.
 
 ```bash
-cargo run -p hamoru-cli -- providers test
-cargo run -p hamoru-cli -- run -m claude:claude-sonnet-4-6 "Hello, world!"
+cargo run --bin hamoru -- providers test
+cargo run --bin hamoru -- run -m claude:claude-sonnet-4-6 "Hello, world!"
 ```
 
 ### More examples
 
 ```bash
 # Policy-based model selection
-cargo run -p hamoru-cli -- run -p cost-optimized "Summarize this text"
+cargo run --bin hamoru -- run -p cost-optimized "Summarize this text"
 
 # Tag-based routing
-cargo run -p hamoru-cli -- run --tags review "Review this code for security issues"
+cargo run --bin hamoru -- run --tags review "Review this code for security issues"
 
 # Multi-step workflow
-cargo run -p hamoru-cli -- run -w workflow.yaml "Implement an auth API"
+cargo run --bin hamoru -- run -w workflow.yaml "Implement an auth API"
 ```
 
 ## 🔑 Environment Variables

--- a/crates/hamoru-cli/Cargo.toml
+++ b/crates/hamoru-cli/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[[bin]]
+name = "hamoru"
+path = "src/main.rs"
+
 [dependencies]
 hamoru-core = { path = "../hamoru-core" }
 chrono = { version = "0.4.20", features = ["serde"] }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 # smoke-test.sh — E2E smoke test for the hamoru CLI.
 #
-# Binary is `hamoru-cli` (from crate package name; no [[bin]] override).
-# The `hamoru` name shown in --help comes from #[command(name = "hamoru")]
-# and does not affect the binary filename.
+# Binary is `hamoru` (via [[bin]] in hamoru-cli crate's Cargo.toml).
 #
 # Usage:
 #   bash scripts/smoke-test.sh              # auto-detect (offline if no API key)
 #   bash scripts/smoke-test.sh --offline    # force offline only
 #   bash scripts/smoke-test.sh --verbose    # show stdout/stderr for every test
-#   HAMORU_BIN=/path/to/hamoru-cli bash scripts/smoke-test.sh  # pre-built binary
+#   HAMORU_BIN=/path/to/hamoru bash scripts/smoke-test.sh  # pre-built binary
 #
 # Exit codes:
 #   0 — all attempted tests passed
@@ -70,12 +68,12 @@ if [[ -n "${HAMORU_BIN:-}" ]]; then
   BIN="$(cd "$(dirname "$HAMORU_BIN")" && pwd)/$(basename "$HAMORU_BIN")"
 else
   # Build from source
-  echo "Building hamoru-cli..."
+  echo "Building hamoru..."
   if ! cargo build --manifest-path "${REPO_ROOT}/Cargo.toml" 2>&1; then
     echo "ERROR: cargo build failed. Set HAMORU_BIN to use a pre-built binary." >&2
     exit 2
   fi
-  BIN="${REPO_ROOT}/target/debug/hamoru-cli"
+  BIN="${REPO_ROOT}/target/debug/hamoru"
   if [[ ! -x "$BIN" ]]; then
     echo "ERROR: Binary not found at $BIN after build." >&2
     exit 2


### PR DESCRIPTION
## Summary
- Add `[[bin]]` section to `hamoru-cli` crate so the compiled binary is named `hamoru` instead of `hamoru-cli`
- Update CI workflows, smoke test script, and README to reference the new binary name
- Crate name remains `hamoru-cli`; only the binary output changes

## Test plan
- [x] `cargo build` produces `target/debug/hamoru`
- [x] `cargo run --bin hamoru -- --help` works correctly
- [x] `cargo test --workspace` — 297 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/smoke-test.sh --offline` — 19 passed, 0 failed

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)