### PR TITLE
🐛 fix: add --label to issue creation in /implement Step 2a

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -91,11 +91,13 @@ After fetching the issue, check for an existing plan comment:
   Set `ISSUE_NUMBER=N`.
 
 **Otherwise** (new task — always create issue, because checkpoint sync and resumption require a `COMMENT_ID` on a real Issue):
+- Determine `LABEL` from `TASK_TYPE` using the label mapping table in Step 5.
 - Create a new issue:
   ```bash
   ISSUE_URL=$(gh issue create \
     --title "{EMOJI} {TASK_TYPE}: {TITLE}" \
     --assignee "@me" \
+    --label "$LABEL" \
     --body "$(cat <<'HAMORU_ISSUE'
   ## Summary
   {1-3 sentence summary from plan}


### PR DESCRIPTION
## Summary
- Step 2a (issue creation) was missing `--label` flag, while Step 5 (PR creation) correctly applied labels from the TASK_TYPE mapping table
- Added `--label "$LABEL"` to `gh issue create` and a note to derive LABEL from Step 5's mapping table

## Test plan
- [x] Verified issue #43 was created with `bug` label using the updated flow

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)